### PR TITLE
Only declare DegreeOfMatrixGroup if it is missing

### DIFF
--- a/lib/irredsol.gd
+++ b/lib/irredsol.gd
@@ -226,7 +226,11 @@ DeclareGlobalFunction("OneIrreducibleSolvableGroup");
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareSynonymAttr ("DegreeOfMatrixGroup", DimensionOfMatrixGroup);
+if not IsBound(DegreeOfMatrixGroup) then
+    # DegreeOfMatrixGroup is also declared identically in irredsol, so to
+    # avoid warnings we only define it if necessary
+    DeclareSynonymAttr("DegreeOfMatrixGroup", DimensionOfMatrixGroup);
+fi;
 
 #############################################################################
 ##


### PR DESCRIPTION
This avoids a warning when loading primgrp after irredsol 1.4.1 or later.

See also https://github.com/bh11/irredsol/pull/11