### PR TITLE
Do not test 32-bit build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }}
+    name: ${{ matrix.gap-branch }}
     runs-on: ubuntu-latest
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -19,17 +19,12 @@ jobs:
           - master
           - stable-4.11
           - stable-4.10
-        ABI: ['']
-        include:
-          - gap-branch: master
-            ABI: 32
 
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap-for-packages@v1
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
-          ABI: ${{ matrix.ABI }}
       - uses: gap-actions/run-test-for-packages@v1
 
   # The documentation job


### PR DESCRIPTION
32-bit builds failed to upload code coverage. We may disable only that upload perhaps, OTOH, this package does not use binaries, so there is little chance to uncover new problems in 32-bit tests here (we still perform 32-bit tests on Jenkins in St Andrews).