### PR TITLE
Remove PRIMLOAD, make PRIMGRP read-only

### DIFF
--- a/lib/primitiv.gi
+++ b/lib/primitiv.gi
@@ -24,41 +24,18 @@ Unbind(PRIMGRP);
 ##  7: name
 ##  8: socle type
 ##  9: generators
-PRIMGRP:=[];
-
-#############################################################################
-##
-#V  PRIMLOAD
-##
-##  Queue of order in which the groups were loaded.
-PRIMLOAD:=[];
+BindGlobal("PRIMGRP", []);
 
 BindGlobal("PrimGrpLoad",function(deg)
-local s,fname,ind,new;
+local s,fname,ind;
   if not IsBound(PRIMGRP[deg]) then
     if not (deg in PRIMRANGE and IsBound(PRIMINDX[deg])) then
       Error("Primitive groups of degree ",deg," are not known!");
     fi;
 
-    # are there too many groups stored?
-    s:=Sum(Filtered(PRIMGRP,i->IsBound(i)),Length);
-    if IsBound(PRIMLOAD[1]) then
-      while s>200 do
-        s:=s-PRIMLENGTHS[PRIMLOAD[1]];
-        Unbind(PRIMGRP[PRIMLOAD[1]]);
-        PRIMLOAD:=PRIMLOAD{[2..Length(PRIMLOAD)]};
-      od;
-    fi;
-
     ind:=PRIMINDX[deg];
-    new:=Filtered([1..Length(PRIMINDX)],i->PRIMINDX[i]=ind);
     fname:=Concatenation("gps",String(ind));
     ReadPackage( "primgrp", Concatenation( "data/", fname, ".g" ) );
-
-    # store the degree
-    PRIMLOAD:=Filtered(PRIMLOAD,i->not i in new);
-    Append(PRIMLOAD,new);
-
   fi;
 end);
 


### PR DESCRIPTION
Making PRIMGRP read-only prevents accidental deletion or redefinitions
of this variable. Note that its *content* remains modifiable.

Also completely remove PRIMLOAD. This variable apparently was meant to
model a LRU (least recently used) cache. But it did not work correctly,
and according to my measurements, with all data loaded, the memory usage
according to `MemoryUsage(PRIMGRP)` is only about 50 MB, which is
neglible these days. So repairing the LRU cache doesn't seem worth the
bother. If we are concerned about it, we could hook into `FlushCaches`
to let the user delete this data.

To explain what was wrong with this LRU cache, consider the following
scenario: Some code creates a primitive group of degree 60. Now instead
of storing in PRIMLOAD that degree 60 was requested, the code stored
*all* degrees that were loaded by the request, i.e., degrees 1-150.

Suppose now that the next request is for a group of degree 180. This
first unloads data until we get under a certain threshold -- in practice
it ended up unloading all data for degrees 1-125, so in particular the
earlier requested degree 60 was unloaded. Afterwards the data for
degrees 126-300 was in memory. If the next request is again for degree
60, then we end up with degrees 281-300 and 1-150 in memory -- so the
degree 180 got unloaded. If we thus alternate between degree 60 and 180,
we keep re-loading the same data, while preserving data the code never
ever even asked for.

Clearly this is *not* what was intended.
