### PR TITLE
Update CI to use setup-gap@v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,35 +19,30 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.16
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
-          - stable-4.11
-          - stable-4.10
+        gap-version:
+          - 'devel'   # current GAP development version from git
+          - 'latest'  # latest GAP release
+          - 'minimal' # oldest GAP release supported by this package
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/build-pkg@v3
+      - uses: gap-actions/run-pkg-tests@v4
         with:
-          GAP_TESTFILE: "tst/teststandard.g"
-      - uses: gap-actions/run-pkg-tests@v3
+          testfile: "tst/teststandard.g"
+      - uses: gap-actions/run-pkg-tests@v4
         with:
-          GAP_TESTFILE: "tst/teststandard.g"
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
+          testfile: "tst/teststandard.g"
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Update the CI workflow to use current gap-actions releases, migrate legacy inputs, and standardize the GAP version matrix.